### PR TITLE
feat: support hyperlinks for `inertia` helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ This extension brings Inertia.js support to Visual Studio Code.
 ![](.github/hyperlink.png)
 
 This extension adds hyperlinks to the name of your components inside
-`Inertia::render` and `Route::inertia` method calls. This allows you to easily
-navigate to the corresponding component using `CTRL+click`.
+`Inertia::render`, `Route::inertia` and `inertia` method calls. This allows you
+to easily navigate to the corresponding component using `CTRL+click`.
 
 Use it to:
 
@@ -20,4 +20,5 @@ customize this path with the `inertia.pagesFolder` setting.
 
 # License
 
-This VS Code extension is open source software releaser under the [MIT License](./LICENSE.md).
+This VS Code extension is open source software released under the
+[MIT License](./LICENSE.md).

--- a/src/providers/inertiaComponentLink.provider.ts
+++ b/src/providers/inertiaComponentLink.provider.ts
@@ -18,6 +18,12 @@ export class InertiaComponentLinkProvider implements DocumentLinkProvider {
     provideDocumentLinks(
         document: TextDocument
     ): ProviderResult<DocumentLink[]> {
+        // https://regex101.com/r/e38QDW/1
+        const helperRegex = new RegExp(
+            'inertia\\(\\s*([\'"])(?<component>.+)(\\1)\\s*\\)',
+            'gmd'
+        );
+
         // https://regex101.com/r/4Bge9d/1
         const renderRegex = new RegExp(
             'Inertia::render\\(\\s*([\'"])(?<component>.+)(\\1)\\s*\\)',
@@ -31,7 +37,8 @@ export class InertiaComponentLinkProvider implements DocumentLinkProvider {
         );
 
         const components = [
-            ...locateInDocument(renderRegex, 'component', document),
+            ...locateInDocument(helperRegex, 'component', document),
+            ...locateInDocument(routesRegex, 'component', document),
             ...locateInDocument(routesRegex, 'component', document),
         ];
 

--- a/test/fixtures/routes.php
+++ b/test/fixtures/routes.php
@@ -3,3 +3,5 @@
 Route::inertia('event', 'Some/Page');
 
 Inertia::render('Help');
+
+inertia('Help');


### PR DESCRIPTION
This PR adds support for recognizing component names in `inertia` helper function calls.

```php
inertia('Some/Component');
```

Closes #5 