### PR TITLE
fix: non-vue support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,16 +11,35 @@ This extension brings Inertia.js support to Visual Studio Code.
 
 ## Configuration
 
-Set the `inertia.pages` setting to a glob pattern that matches the components
-that should appear in the autocompletion dialog. The extension also uses this
-glob pattern to determine the root folder of your components.
+### `inertia.pages`
 
-For example, if your page components live under `resources/js/Pages`, you may
-want to use the following glob pattern:
+The `inertia.pages` setting must be a glob pattern that matches the components
+that should appear in the auto-completion dialog. This pattern is resolved
+relative to your workspace's root folder.
 
-```
-resources/js/Pages/**/*.vue
-```
+The extension also uses this pattern to determine the root folder of your
+components, which in turn is used to generate the hyperlinks to your page
+components.
+
+Here a some common patterns for different project types:
+
+| Project type    | Pattern                       |
+| --------------- | ----------------------------- |
+| Laravel + Vue   | `resources/js/Pages/**/*.vue` |
+| Laravel + React | `resources/js/Pages/**/*.tsx` |
+
+### `inertia.defaultExtension`
+
+When the extension generates hyperlinks to components that do not yet exist on
+the filesystem, it cannot guess which file extension to use because the glob
+pattern declared in `inertia.pages` may contain multiple file extensions. The
+extension uses this setting to creates hyperlinks with the correct file
+extension.
+
+| Project type | Pattern |
+| ------------ | ------- |
+| Vue          | `.vue`  |
+| React        | `.tsx`  |
 
 # License
 

--- a/package.json
+++ b/package.json
@@ -54,6 +54,11 @@
                         "type": "string",
                         "default": "resources/js/Pages/**/*.vue",
                         "description": "A glob pattern to match the Vue components that you use as pages in your Inertia application. The root folder of your components is inferred from the glob pattern."
+                    },
+                    "inertia.defaultExtension": {
+                        "type": "string",
+                        "default": ".vue",
+                        "description": "The default file extension to use when generating hyperlinks to components that do not yet exist on the filesystem."
                     }
                 }
             }

--- a/src/providers/inertiaComponentLink.provider.ts
+++ b/src/providers/inertiaComponentLink.provider.ts
@@ -81,7 +81,14 @@ export class InertiaComponentLinkProvider implements DocumentLinkProvider {
                     });
 
                     return {
-                        target: file,
+                        target: Uri.joinPath(
+                            workspaceURI,
+                            unglob(pages),
+                            component.value +
+                                workspace
+                                    .getConfiguration('inertia')
+                                    .get('defaultExtension', '.vue')
+                        ),
                         range: component.range,
                     } as DocumentLink;
                 });

--- a/src/providers/inertiaComponentLink.provider.ts
+++ b/src/providers/inertiaComponentLink.provider.ts
@@ -71,10 +71,7 @@ export class InertiaComponentLinkProvider implements DocumentLinkProvider {
         });
     }
 
-    resolveDocumentLink(
-        link: DocumentLink,
-        token: CancellationToken
-    ): ProviderResult<DocumentLink> {
+    resolveDocumentLink(link: DocumentLink): ProviderResult<DocumentLink> {
         const document = window.activeTextEditor?.document;
         if (!document) {
             return undefined;

--- a/src/providers/inertiaComponentLink.provider.ts
+++ b/src/providers/inertiaComponentLink.provider.ts
@@ -81,7 +81,7 @@ export class InertiaComponentLinkProvider implements DocumentLinkProvider {
                     });
 
                     return {
-                        target: Uri.joinPath(
+                        target: file ?? Uri.joinPath(
                             workspaceURI,
                             unglob(pages),
                             component.value +
@@ -92,9 +92,6 @@ export class InertiaComponentLinkProvider implements DocumentLinkProvider {
                         range: component.range,
                     } as DocumentLink;
                 });
-            })
-            .then((links) => {
-                return links.filter((link) => link.target);
             });
     }
 }


### PR DESCRIPTION
This PR fixes the extension so that hyperlinks also work with non-Vue projects.

- [x] Find any files via the user-supplied glob pattern
- [x] Create link to existing file
- [x] Create link to non-existing files (using the new `defaultExtension` setting)  
- [x] Delay links resolution to after clicked to that renaming files does not affect hyperlinks

Fixes #13 