### PR TITLE
fix: inertia helper regex

### DIFF
--- a/src/providers/inertiaComponentLink.provider.ts
+++ b/src/providers/inertiaComponentLink.provider.ts
@@ -21,10 +21,10 @@ export class InertiaComponentLinkProvider implements DocumentLinkProvider {
     provideDocumentLinks(
         document: TextDocument
     ): ProviderResult<DocumentLink[]> {
-        // https://regex101.com/r/YiSfGR/2
+        // https://regex101.com/r/YiSfGR/5
         const helperRegex = new RegExp(
-            '^(?!Route::)inertia\\(\\s*([\'"])(?<component>(?:(?!\\1).)*)(\\1)\\s*(?:,[\\s\\S]*?)?\\);',
-            'gmd'
+            '^(?!.*Route::inertia).*inertia\\(\\s*([\'"])(?<component>.+)(\\1)\\s*(?:,[\\s\\S]*?)?\\)', 
+            'gdm'
         );
 
         // https://regex101.com/r/FheqGS/1


### PR DESCRIPTION
This PR:

- [x] Fixes the regex that is used to match components in the `inertia` helper.

Fixes #19 